### PR TITLE
feat(connection options): Adding ability to pass options through to connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,36 @@ A helper grunt task to manage Mongoose MongoDB database migrations.
           path: "#{__dirname}/migrations"
           template: grunt.file.read "#{__dirname}/migrations/_template.coffee" # optional
           mongo: 'mongodb://localhost:12345'
-          ext: "coffee" # default `coffee`
+          ext: "coffee"
+
+#### Options
+
+##### path (required)
+Type: `String`  
+Path to directory containing migrations.
+
+##### template
+Type: `String`  
+Template for generating new migration files.
+
+##### mongo
+Type: `String` | `Object` | `Function`  
+If a string is specified, it is the connection string for MongoDB. If an object is specified, it may have two properties: `uri` (required) which is the connection string, and `opts` which will be passed through to `mongoose.createConnection`. Ex:
+
+    grunt.initConfig
+      migrations:
+        path: "#{__dirname}/migrations"
+        mongo:
+          uri: 'mongodb://localhost:12345'
+          opts:
+            ssl: true
+If a function is specified, it must return either a string or object as described above.
+
+##### ext
+Type: `String`  
+Default: `'coffee'`  
+Values: `'coffee'` | `'js'`  
+Migrations file extension.
 
 ### _template.coffee
 
@@ -42,7 +71,7 @@ By default the task will generate a migration in CoffeeScript using the same tem
       up: (callback) ->
         // your migration goes here
         callback()
-        
+
       down: (callback) ->
         // throw new Error('Irreversible migration.');
         callback()
@@ -106,7 +135,7 @@ Running this again will do nothing because all migrations have been ran.
     >> Finished migrations
 
     Done, without errors.
-    
+
 ### migrate:down
 
 Runs down the last migration.

--- a/mongo_migrate.coffee
+++ b/mongo_migrate.coffee
@@ -7,7 +7,14 @@ class Migrate
   constructor: (@opts, @model) ->
     unless @model?
       @opts.mongo = @opts.mongo() if typeof @opts.mongo is 'function'
-      connection = mongoose.createConnection @opts.mongo
+
+      if @opts.mongo.hasOwnProperty 'uri'
+        {uri, opts} = @opts.mongo
+      else
+        uri = @opts.mongo
+        opts = undefined
+
+      connection = mongoose.createConnection uri, opts
 
       schema = new mongoose.Schema
         name:  type: String, index: true, unique: true, required: true
@@ -100,4 +107,3 @@ class Migrate
     filename
 
 module.exports = Migrate
-

--- a/mongo_migrate.js
+++ b/mongo_migrate.js
@@ -12,14 +12,20 @@ slugify = require('slugify');
 
 Migrate = (function() {
   function Migrate(opts, model) {
-    var connection, schema, _base, _base1;
+    var connection, schema, uri, _base, _base1, _ref;
     this.opts = opts;
     this.model = model;
     if (this.model == null) {
       if (typeof this.opts.mongo === 'function') {
         this.opts.mongo = this.opts.mongo();
       }
-      connection = mongoose.createConnection(this.opts.mongo);
+      if (this.opts.mongo.hasOwnProperty('uri')) {
+        _ref = this.opts.mongo, uri = _ref.uri, opts = _ref.opts;
+      } else {
+        uri = this.opts.mongo;
+        opts = void 0;
+      }
+      connection = mongoose.createConnection(uri, opts);
       schema = new mongoose.Schema({
         name: {
           type: String,


### PR DESCRIPTION
Depending on the MongoDB deployment, you may have to specify connection options. This PR will allow you to pass options through to the `mongoose.createConnection` call. It is fully backwards compatible and I added tests to ensure previous and new functionality.
